### PR TITLE
Feat/ add all unit tests to plays and facade with 100% coverage

### DIFF
--- a/src/lucy-guy.test.ts
+++ b/src/lucy-guy.test.ts
@@ -1,0 +1,96 @@
+import { LuckyGuy } from './lucy-guy';
+import { Binary } from './plays/binary';
+import { Custom } from './plays/custom';
+import { FlipCoin } from './plays/flip-coin';
+import { OneTwoGo } from './plays/one-two-go';
+import { RollDice } from './plays/roll-dice';
+import { SaySomething } from './plays/say-something';
+import { ShakeHand } from './plays/shake-hand';
+import { ShowLetter } from './plays/show-letter';
+
+describe(LuckyGuy.name, () => {
+  let luckyGuy: LuckyGuy;
+
+  beforeEach(() => {
+    luckyGuy = new LuckyGuy();
+  });
+
+  test('should get and set language', () => {
+    expect(luckyGuy.language).toBe('en');
+    luckyGuy.language = 'pt';
+    expect(luckyGuy.language).toBe('pt');
+  });
+
+  test('should play binary game', () => {
+    const binaryPlayMock = jest
+      .spyOn(Binary.prototype, 'play')
+      .mockReturnValue(1);
+    expect(luckyGuy.binary()).toBe(1);
+    expect(binaryPlayMock).toHaveBeenCalled();
+  });
+
+  test('should roll a dice with default sides', () => {
+    const rollDiceMock = jest
+      .spyOn(RollDice.prototype, 'play')
+      .mockReturnValue(4);
+    expect(luckyGuy.dice()).toBe(4);
+    expect(rollDiceMock).toHaveBeenCalledWith(6);
+  });
+
+  test('should roll a dice with specified sides', () => {
+    const rollDiceMock = jest
+      .spyOn(RollDice.prototype, 'play')
+      .mockReturnValue(10);
+    expect(luckyGuy.dice(10)).toBe(10);
+    expect(rollDiceMock).toHaveBeenCalledWith(10);
+  });
+
+  test('should flip a coin', () => {
+    const flipCoinMock = jest
+      .spyOn(FlipCoin.prototype, 'play')
+      .mockReturnValue('Heads');
+    expect(luckyGuy.coin()).toBe('Heads');
+    expect(flipCoinMock).toHaveBeenCalled();
+  });
+
+  test('should return confirmation', () => {
+    const saySomethingMock = jest
+      .spyOn(SaySomething.prototype, 'play')
+      .mockReturnValue('Yes');
+    expect(luckyGuy.confirmation()).toBe('Yes');
+    expect(saySomethingMock).toHaveBeenCalled();
+  });
+
+  test('should play jokenpo', () => {
+    const shakeHandMock = jest
+      .spyOn(ShakeHand.prototype, 'play')
+      .mockReturnValue('Rock');
+    expect(luckyGuy.jokenpo()).toBe('Rock');
+    expect(shakeHandMock).toHaveBeenCalled();
+  });
+
+  test('should return a random letter', () => {
+    const showLetterMock = jest
+      .spyOn(ShowLetter.prototype, 'play')
+      .mockReturnValue('A');
+    expect(luckyGuy.alphabet()).toBe('A');
+    expect(showLetterMock).toHaveBeenCalled();
+  });
+
+  test('should play odds and evens', () => {
+    const oneTwoGoMock = jest
+      .spyOn(OneTwoGo.prototype, 'play')
+      .mockReturnValue('Even');
+    expect(luckyGuy.oddsAndEvens(2, 2)).toBe('Even');
+    expect(oneTwoGoMock).toHaveBeenCalledWith(4);
+  });
+
+  test('should play a custom game', () => {
+    const customMock = jest
+      .spyOn(Custom.prototype, 'play')
+      .mockReturnValue('Option 1');
+    const options = ['Option 1', 'Option 2'];
+    expect(luckyGuy.custom(options)).toBe('Option 1');
+    expect(customMock).toHaveBeenCalledWith();
+  });
+});

--- a/src/lucy-guy.ts
+++ b/src/lucy-guy.ts
@@ -34,8 +34,8 @@ export class LuckyGuy {
    * @param language - The language to use for operations that depend on localization.
    * @default 'en' (English)
    */
-  constructor(language: Language) {
-    this.#language = language;
+  constructor(language?: Language) {
+    this.#language = language || 'en';
   }
 
   /**

--- a/src/tests/plays/binary.test.ts
+++ b/src/tests/plays/binary.test.ts
@@ -1,0 +1,14 @@
+import { Binary } from '../../plays/binary';
+
+describe(Binary.name, () => {
+  let binary: Binary;
+
+  beforeEach(() => {
+    binary = new Binary();
+  });
+
+  test('should return 0 or 1 when play is called', () => {
+    const result = binary.play();
+    expect([0, 1]).toContain(result);
+  });
+});

--- a/src/tests/plays/custom.test.ts
+++ b/src/tests/plays/custom.test.ts
@@ -1,0 +1,15 @@
+import { Custom } from '../../plays/custom';
+
+describe(Custom.name, () => {
+  const mock = ['Batman', 'Superman', 'Wonder Woman', 'Green Lantern'];
+  let custom: Custom;
+
+  beforeEach(() => {
+    custom = new Custom(mock);
+  });
+
+  test('should return one of Justice League heroes', () => {
+    const result = custom.play();
+    expect(mock).toContain(result);
+  });
+});

--- a/src/tests/plays/flip-coin.test.ts
+++ b/src/tests/plays/flip-coin.test.ts
@@ -1,0 +1,15 @@
+import { FlipCoin } from '../../plays/flip-coin';
+
+describe(FlipCoin.name, () => {
+  const mock = ['Heads', 'Tails'];
+  let coin: FlipCoin;
+
+  beforeEach(() => {
+    coin = new FlipCoin();
+  });
+
+  test('should return Heads or Tails', () => {
+    const result = coin.play();
+    expect(mock).toContain(result);
+  });
+});

--- a/src/tests/plays/one-two-go.test.ts
+++ b/src/tests/plays/one-two-go.test.ts
@@ -1,0 +1,33 @@
+import { OneTwoGo } from '../../plays/one-two-go';
+import { RollDice } from '../../plays/roll-dice';
+
+describe(OneTwoGo.name, () => {
+  test('should return Ímpar or Par', () => {
+    const hand = new OneTwoGo('pt');
+    const mock = ['Ímpar', 'Par'];
+    expect(mock).toContain(generateResult(hand));
+  });
+
+  test('should return Odd or Even', () => {
+    const hand = new OneTwoGo();
+    const mock = ['Odd', 'Even'];
+    expect(mock).toContain(generateResult(hand));
+  });
+
+  test('should return Odd', () => {
+    const hand = new OneTwoGo();
+    expect(hand.play(5)).toBe('Odd');
+    expect(hand.play(4)).not.toBe('Odd');
+  });
+
+  test('should return Even', () => {
+    const hand = new OneTwoGo();
+    expect(hand.play(4)).toBe('Even');
+    expect(hand.play(5)).not.toBe('Even');
+  });
+
+  function generateResult(hand: OneTwoGo) {
+    const players = [new RollDice().play(10), new RollDice().play(10)];
+    return hand.play(players[0] + players[1]);
+  }
+});

--- a/src/tests/plays/roll-dice.test.ts
+++ b/src/tests/plays/roll-dice.test.ts
@@ -1,0 +1,17 @@
+import { RollDice } from '../../plays/roll-dice';
+
+describe(RollDice.name, () => {
+  let rollDice: RollDice;
+
+  beforeEach(() => {
+    rollDice = new RollDice();
+  });
+
+  test('should return 1 to 6 when play is called', () => {
+    const mock = [1, 2, 3, 4, 5, 6];
+    const result = rollDice.play(6);
+    expect(mock).toContain(result);
+    expect(mock).not.toContain(7);
+    expect(mock).not.toContain(0);
+  });
+});

--- a/src/tests/plays/say-something.test.ts
+++ b/src/tests/plays/say-something.test.ts
@@ -1,0 +1,15 @@
+import { SaySomething } from '../../plays/say-something';
+
+describe(SaySomething.name, () => {
+  const mock = ['Yes', 'No'];
+  let saySomething: SaySomething;
+
+  beforeEach(() => {
+    saySomething = new SaySomething();
+  });
+
+  test('should return Yes or No', () => {
+    const result = saySomething.play();
+    expect(mock).toContain(result);
+  });
+});

--- a/src/tests/plays/shake-hand.test.ts
+++ b/src/tests/plays/shake-hand.test.ts
@@ -1,0 +1,15 @@
+import { ShakeHand } from '../../plays/shake-hand';
+
+describe(ShakeHand.name, () => {
+  const mock = ['Pedra', 'Papel', 'Tesoura'];
+  let hand: ShakeHand;
+
+  beforeEach(() => {
+    hand = new ShakeHand('pt');
+  });
+
+  test('should return Pedra, Papel or Tesoura', () => {
+    const result = hand.play();
+    expect(mock).toContain(result);
+  });
+});

--- a/src/tests/plays/show-letter.test.ts
+++ b/src/tests/plays/show-letter.test.ts
@@ -1,0 +1,14 @@
+import { ShowLetter } from '../../plays/show-letter';
+
+describe(ShowLetter.name, () => {
+  let adedonha: ShowLetter;
+
+  beforeEach(() => {
+    adedonha = new ShowLetter();
+  });
+
+  test('should return a letter', () => {
+    const result = adedonha.play();
+    expect(result).toMatch(/^[a-zA-Z]+$/);
+  });
+});


### PR DESCRIPTION
This merge request adds unit tests for all classes extending the `Play` class, ensuring full test coverage for the following game logic:
- `Binary`
- `Custom`
- `FlipCoin`
- `OneTwoGo`
- `RollDice`
- `SaySomething`
- `ShakeHand`
- `ShowLetter`

Each class was thoroughly tested to validate their core functionalities, including randomization, localization, and specific game logic. The tests mock necessary methods and include different edge cases for input and output validation.

All tests have passed successfully, ensuring the reliability of the "play" components.

![unittests](https://github.com/user-attachments/assets/fd22b6ee-4d26-4fae-bbd9-1ade057a0ccb)

