### PR TITLE
ci: add Github permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.2.2](https://github.com/MatheusMFranco/luck-guy-js/compare/v1.2.1...v1.2.2) (2024-10-14)
+
 ### [1.2.1](https://github.com/MatheusMFranco/luck-guy-js/compare/v1.2.0...v1.2.1) (2024-10-14)
 
 ## [1.2.0](https://github.com/MatheusMFranco/luck-guy-js/compare/v1.1.0...v1.2.0) (2024-10-14)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "super-lucky-guy",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A simplified interface for interacting with various 'starter' games.",
   "main": "dist/index.js",
   "types": "dist/@types/lucky-guy.d.ts",


### PR DESCRIPTION
For GitHub to create the tag and pass the GitHub Actions pipeline, it was necessary to add a write permission to the automation file.